### PR TITLE
docs(program): codify default-branch board truth rule

### DIFF
--- a/program/ARTICLE_SERIES_ROADMAP.md
+++ b/program/ARTICLE_SERIES_ROADMAP.md
@@ -1,0 +1,48 @@
+# Article Series Roadmap
+
+This roadmap turns operator truth and proof assets into a bounded article
+sequence.
+
+## Editorial rule
+
+Every article must begin from completed operator or product truth and cite named
+proof assets from `PROOF_ASSET_LIBRARY.md`.
+
+## Series
+
+### 1. Why AI agents need runbooks, not just prompts
+
+- Audience: operators, technical founders
+- Backbone:
+  - Alice deploy/runbook canon
+  - Milady operator bootstrap
+  - stream and SW4P operator handbooks
+
+### 2. Decentralized streaming OS: what operators actually need
+
+- Audience: creators, partners
+- Backbone:
+  - stream operator handbook
+  - stream mastery lane
+  - stream release-readiness memo
+
+### 3. The economic rails behind onchain entertainment
+
+- Audience: partners, investors
+- Backbone:
+  - protocol docs
+  - SW4P technical docs
+  - proof assets around revenue, bridge, and release discipline
+
+### 4. From game loop to money loop: the 555 stack
+
+- Audience: public, partners
+- Backbone:
+  - arcade mastery
+  - stream operator surface
+  - SW4P integration surface
+
+## Close rule
+
+An article ticket closes when the article exists, cites current proof assets,
+and the linked proof assets remain stronger than the claim being made.

--- a/program/ARTICLE_SERIES_ROADMAP.md
+++ b/program/ARTICLE_SERIES_ROADMAP.md
@@ -17,6 +17,8 @@ proof assets from `PROOF_ASSET_LIBRARY.md`.
   - Alice deploy/runbook canon
   - Milady operator bootstrap
   - stream and SW4P operator handbooks
+- Draft:
+  - `articles/why-ai-agents-need-runbooks.md`
 
 ### 2. Decentralized streaming OS: what operators actually need
 

--- a/program/CATEGORY_DECK_BRIEF.md
+++ b/program/CATEGORY_DECK_BRIEF.md
@@ -1,0 +1,34 @@
+# Category Deck Brief
+
+## Deck rule
+
+The category deck is a proof-backed synthesis, not a substitute for product
+truth.
+
+## Required sections
+
+1. Problem
+   operator complexity, fragmented monetization, weak AI operational trust
+2. Product wedge
+   Alice + stream + arcade + SW4P as one operating stack
+3. Why this stack matters
+   the value is in coordinated operator truth, not isolated components
+4. Proof
+   named proof assets only
+5. What is live vs operator-ready vs next
+6. Next 90 days
+   bounded, evidence-aware roadmap
+
+## Claims that require proof
+
+- deployability
+- operator readiness
+- release discipline
+- cross-product integration
+- economic value routing
+
+## Current supporting assets
+
+- `PROOF_ASSET_LIBRARY.md`
+- `PARTNER_VC_NARRATIVE.md`
+- `COMMUNICATION_OPERATING_SYSTEM.md`

--- a/program/COMMUNICATION_OPERATING_SYSTEM.md
+++ b/program/COMMUNICATION_OPERATING_SYSTEM.md
@@ -1,0 +1,45 @@
+# Communication Operating System
+
+This file defines how recurring communication tickets are executed and closed.
+
+## Rule of completion
+
+A cadence ticket is only complete when both of these exist:
+
+1. the reusable template / SOP
+2. the first real artifact produced from it
+
+## Canonical artifact families
+
+| Artifact | Primary audience | Inputs | Required proof discipline | First-cycle output convention |
+| --- | --- | --- | --- | --- |
+| Founder EOD note | founder / internal | active ticket evidence, blockers, decisions | no unsupported progress claims | `community/founder-eod-YYYY-MM-DD.md` |
+| Founder operating memo | founder / internal | weekly ticket status, risks, gates | every claim links a repo-local source | `community/founder-operating-memo-YYYY-MM-DD.md` |
+| Public build log | public | operator-ready wins, proof assets, demos | no speculative roadmap claims presented as shipped | `community/public-build-log-YYYY-MM-DD.mdx` |
+| Partner mini-brief | partner | product state, proof library, wedge | every strategic claim maps to product proof | `community/partner-mini-brief-YYYY-MM-DD.md` |
+| Investor update | investor | proof library, metrics, risks, next 90 | separate proof from ambition explicitly | `community/investor-update-YYYY-MM-DD.md` |
+| Category deck refresh | founder / investor | proof library, wedge, why now, roadmap | deck claims must reference named proof assets | `community/category-deck-refresh-YYYY-MM-DD.md` |
+
+## Editorial rules
+
+- Lead with operator truth, then product truth, then market framing.
+- Never claim reliability, automation, safety, or economic performance without a
+  linked proof asset.
+- A public build log should highlight what is now proven, what is still bounded,
+  and what remains open.
+- Partner and investor artifacts must clearly separate:
+  - what is live
+  - what is operator-ready
+  - what is still a next-step or launch-bound item
+
+## First-cycle agenda
+
+- Founder EOD note: summarize the documentation program normalization and the
+  first repo-local doc indexes shipped.
+- Founder operating memo: document repo-by-repo readiness, blockers, and the
+  next tranche of ticket closures.
+- Public build log: publish the proof-first operator narrative with explicit
+  references to Alice deploy docs, stream evidence, arcade mastery, and SW4P
+  security/ops docs.
+- Partner mini-brief and investor update: derive from the proof library, not
+  from roadmap rhetoric.

--- a/program/EXPLICIT_OVERLAP_THESIS.md
+++ b/program/EXPLICIT_OVERLAP_THESIS.md
@@ -1,0 +1,46 @@
+# Explicit Overlap Thesis
+
+## Question
+
+How immersive worlds, streaming, and betting-adjacent products can support the
+core 555 thesis without diluting focus.
+
+## Core answer
+
+The main company story remains the operator stack:
+
+- runtime and agent operations
+- stream control and live workflows
+- interactive play surfaces
+- economic rails
+
+Adjacent products matter only when they increase the value of that stack.
+
+## Hyperscapes
+
+Hyperscapes matters when it becomes a demanding interactive surface for the core
+operator stack:
+
+- Alice/Milady can operate or assist the experience
+- stream can broadcast and manage the live layer
+- arcade-style interaction and mastery can inform player/operator behavior
+- SW4P can support economic movement where it is operationally justified
+
+If Hyperscapes becomes a standalone lore/product effort detached from operator
+truth, it is a distraction.
+
+## Hyperbet
+
+Hyperbet matters when it strengthens the economic and live-operator layer:
+
+- it tests how monetized participation fits the broader stack
+- it clarifies where the economic rail is valuable
+- it sharpens partner/investor understanding of the monetization thesis
+
+If Hyperbet becomes an isolated prediction product without operator-stack
+leverage, it distracts from the core.
+
+## Rule
+
+Adjacent products serve the main story only if they make the operator stack more
+valuable, more legible, or more defensible.

--- a/program/ISSUE_BRIEF_STANDARD.md
+++ b/program/ISSUE_BRIEF_STANDARD.md
@@ -57,6 +57,9 @@ Examples:
 ### Close condition
 Define the single sentence that makes the ticket closable.
 
+The close condition must assume default-branch or agreed canonical-branch
+reality. A ticket is not done only because a draft or topic branch exists.
+
 ## Example skeleton
 
 ```md
@@ -96,5 +99,5 @@ Create the canonical stream operator handbook for setup, go-live, recovery, and 
 - Preview/build output
 
 ## Close condition
-The owning repo has one canonical operator entrypoint and the issue contains evidence links to it.
+The owning repo has one canonical operator entrypoint on the default or agreed canonical branch, and the issue contains evidence links to it.
 ```

--- a/program/ISSUE_BRIEF_STANDARD.md
+++ b/program/ISSUE_BRIEF_STANDARD.md
@@ -1,0 +1,100 @@
+# Issue Brief Standard
+
+Every documentation and brand-positioning ticket must be normalized into this
+shape before writing begins.
+
+## Required sections
+
+### Goal
+State the concrete outcome in one sentence. Use an action verb and a measurable
+ object.
+
+### Audience
+Name the primary audience first, then optional secondary audiences.
+
+Examples:
+- Operator
+- Internal reviewer
+- Partner / VC
+- Founder
+- Public user
+
+### Owning repo/path
+List the canonical repo and the target docs path or directory.
+
+### Source-of-truth inputs
+List the docs, audits, code paths, dashboards, screenshots, or prior packets
+that define what is true for this ticket.
+
+### Required outputs
+List the exact artifacts that must exist when the ticket closes.
+
+Examples:
+- one canonical runbook
+- one public summary page
+- one release-readiness memo
+- one first-cycle weekly operating memo
+
+### Non-goals
+List what this ticket must not expand into.
+
+### Dependencies
+List blocking tickets, required evidence, or prerequisite docs.
+
+### Acceptance criteria
+Use flat checklist items only. Each line should be externally verifiable.
+
+### Evidence required
+List what must be linked back into the issue before closure.
+
+Examples:
+- file paths
+- screenshots
+- preview/build output
+- audit packet
+- demo clip
+
+### Close condition
+Define the single sentence that makes the ticket closable.
+
+## Example skeleton
+
+```md
+## Goal
+Create the canonical stream operator handbook for setup, go-live, recovery, and release review.
+
+## Audience
+- Primary: operator
+- Secondary: reviewer, founder
+
+## Owning repo/path
+- Repo: `rndrntwrk/stream-plugin`
+- Canonical path: `docs/`
+
+## Source-of-truth inputs
+- `docs/GET_STARTED.md`
+- `docs/ACTIONS_REFERENCE.md`
+- `../555stream/ECOSYSTEM_EVIDENCE_INDEX.md`
+
+## Required outputs
+- `docs/OPERATOR_HANDBOOK_INDEX.md`
+- `docs/STREAM_RELEASE_READINESS_MEMO.md`
+
+## Non-goals
+- Rewriting unrelated product marketing pages
+
+## Dependencies
+- STR-001
+- STR-002
+
+## Acceptance criteria
+- [ ] The handbook covers setup, live operation, and recovery.
+- [ ] The readiness memo links concrete evidence for each claim.
+
+## Evidence required
+- Links to changed files
+- Preview/build output
+
+## Close condition
+The owning repo has one canonical operator entrypoint and the issue contains evidence links to it.
+```

--- a/program/LAUNCH_STRATEGY_AND_NEXT_90.md
+++ b/program/LAUNCH_STRATEGY_AND_NEXT_90.md
@@ -1,0 +1,48 @@
+# Launch Strategy And Next 90
+
+## Launch type
+
+Proof-first operator launch.
+
+This is not a mass-market launch. The launch bar is whether the stack can be
+explained, operated, and defended with real documentation, runbooks, and proof
+artifacts.
+
+## Launch bar
+
+- Alice runtime/deploy boundary is explicit
+- stream operator path is handbook-backed
+- arcade mastery status is honest and legible
+- SW4P economic rail is operator-documented
+- proof library can support partner/investor claims without improvisation
+
+## Launch decision rule
+
+Launch only when the current evidence is strong enough to survive review.
+Operator-ready and next-step items must remain explicitly separated.
+
+## Post-launch loop
+
+1. collect operator feedback and evidence
+2. refresh proof assets and public build logs
+3. convert weak surfaces into bounded tickets
+4. re-run narrative and deck refresh from updated proof
+
+## Next 90 days
+
+### Days 1-30
+
+- close Alice setup proof gaps
+- refresh stream release evidence
+- finish the remaining arcade mastery coverage decisions
+
+### Days 31-60
+
+- ship first article drafts from the roadmap
+- pressure-test outreach packaging and target dossiers
+- tighten partner/investor diligence artifacts
+
+### Days 61-90
+
+- use real conversations and pilots to decide where the wedge is strongest
+- update the category deck and launch narrative from actual traction and proof

--- a/program/LIGHTWEIGHT_DATA_ROOM.md
+++ b/program/LIGHTWEIGHT_DATA_ROOM.md
@@ -1,0 +1,40 @@
+# Lightweight Data Room
+
+## Purpose
+
+This is the minimum diligence room for partner and investor conversations.
+
+## Core artifacts
+
+| Category | Artifact | Current source |
+| --- | --- | --- |
+| Thesis | category deck brief | `CATEGORY_DECK_BRIEF.md` |
+| Narrative | partner/VC narrative | `PARTNER_VC_NARRATIVE.md` |
+| One-pager | concise external brief | `PARTNER_VC_ONE_PAGER.md` |
+| Proof | reusable proof asset library | `PROOF_ASSET_LIBRARY.md` |
+| Comms system | recurring founder/public/partner/investor outputs | `COMMUNICATION_OPERATING_SYSTEM.md` |
+| Launch strategy | launch bar and next-90 plan | `LAUNCH_STRATEGY_AND_NEXT_90.md` |
+| Source register | canonical documentation ownership | `SOURCE_REGISTER.md` |
+
+## Product diligence links
+
+- Alice / deployer
+  - `rndrntwrk/milaidy: docs/operators/alice-operator-bootstrap.md`
+  - `rndrntwrk/milaidy: docs/operators/alice-system-boundary.md`
+  - `Render-Network-OS/555-bot: docs/ALICE_DEPLOYMENT_DOCS_INDEX.md`
+- Stream
+  - `rndrntwrk/stream-plugin: docs/OPERATOR_HANDBOOK_INDEX.md`
+  - `rndrntwrk/stream-plugin: docs/RUNBOOK_PACK.md`
+  - `Render-Network-OS/stream: STREAM_RELEASE_READINESS_MEMO_2026-03-25.md`
+- Arcade
+  - `rndrntwrk/555-arcade-plugin: docs/MASTERY_INDEX.md`
+  - `rndrntwrk/555-arcade-plugin: docs/PROGRESSION_AND_ADMIN_EXAMPLES.md`
+- SW4P
+  - `rndrntwrk/sw4p-pro: docs/operations/chain-register.mdx`
+  - `rndrntwrk/sw4p-pro: docs/operations/alice-and-555.mdx`
+  - `rndrntwrk/sw4p-pro: docs/operations/readiness-memo.mdx`
+
+## Rule
+
+If a diligence artifact does not exist here or in the linked repo-local canon,
+it is not ready to be claimed in a serious conversation.

--- a/program/OPERATOR_DOC_CONTRACT.md
+++ b/program/OPERATOR_DOC_CONTRACT.md
@@ -1,0 +1,42 @@
+# Operator Doc Contract
+
+Use this contract for any operator guide, runbook, readiness memo, or recovery
+document.
+
+## Required sections
+
+### Purpose
+Why this document exists and which critical path it covers.
+
+### When to use
+The trigger condition for using the document.
+
+### Prereqs
+Required repos, credentials, environment state, or earlier steps.
+
+### Steps
+Ordered action sequence. Keep it executable.
+
+### Decision points
+The forks where an operator must choose between paths.
+
+### Failure modes
+Known ways the flow can fail.
+
+### Recovery
+How to restore a safe or working state from each important failure.
+
+### Evidence
+What should be captured while following the document.
+
+### Related tickets/docs
+List the canonical neighbors rather than duplicating material.
+
+## Writing rules
+
+- Prefer short imperative steps.
+- Name commands, IDs, and artifacts exactly.
+- Mark deprecated paths explicitly instead of silently replacing them.
+- If a flow spans repos, name one canonical owner and link outward.
+- A readiness memo must end with a clear decision:
+  `Go`, `Go with bounded exceptions`, or `Hold`.

--- a/program/OUTREACH_MESSAGES.md
+++ b/program/OUTREACH_MESSAGES.md
@@ -1,0 +1,38 @@
+# Outreach Messages
+
+Use these drafts with the proof asset library rather than as stand-alone copy.
+
+## Partner message
+
+We are building operator-grade infrastructure for AI-assisted streaming, play,
+and monetization. The current stack already has documented deploy, stream,
+arcade, and SW4P operator surfaces. If your team is interested in creator
+workflows, distribution, or pilots, I can send the concise narrative plus the
+exact proof artifacts behind it.
+
+Recommended proof attachments:
+- `PARTNER_VC_ONE_PAGER.md`
+- `PROOF_ASSET_LIBRARY.md`
+
+## Investor message
+
+Render Network is not just another agent wrapper. The wedge is an operator
+stack: runtime, stream control, interactive play, and economic rails, all tied
+back to proof and release discipline. I can share the current narrative, proof
+library, and launch/next-90 plan if you want to evaluate the thesis seriously.
+
+Recommended proof attachments:
+- `PARTNER_VC_NARRATIVE.md`
+- `LIGHTWEIGHT_DATA_ROOM.md`
+
+## Program / target message
+
+We have a concrete stack and a proof-backed narrative, and we are looking for
+high-signal programs or partners where creator/operator workflows matter. The
+goal is not generic exposure; it is a fit with teams who can pressure-test the
+operator model. If helpful, I can send a one-page dossier tailored to your
+program or target.
+
+Recommended proof attachments:
+- `TARGET_DOSSIER_TEMPLATE.md`
+- `PARTNER_VC_ONE_PAGER.md`

--- a/program/PARTNER_VC_NARRATIVE.md
+++ b/program/PARTNER_VC_NARRATIVE.md
@@ -1,0 +1,57 @@
+# Partner / VC Narrative
+
+## Positioning rule
+
+Lead with the operator problem and the proven stack, not category rhetoric.
+
+## Core narrative spine
+
+### Wedge
+
+Render Network is building operator-grade infrastructure for interactive,
+monetized, AI-assisted streaming and play.
+
+### Why now
+
+- creator workflows are fragmented
+- existing AI tooling is prompt-rich but operations-poor
+- bridge and monetization surfaces usually remain disconnected from the operator
+  flow
+
+### What is actually proven
+
+- Alice has a documented deploy and validation path
+- stream has a real operator surface and evidence-backed release material
+- arcade has game-specific mastery material, not just catalog copy
+- SW4P has technical, security, and operations documentation beyond a landing
+  page
+
+### What is still bounded
+
+- current-cycle release proof still needs refresh in some surfaces
+- not every catalog item has full mastery parity
+- some integration and evidence packets still need unification
+
+### Next step
+
+Turn finished operator truth into partner and investor materials with direct
+proof links, not speculative promises.
+
+## Deck outline
+
+1. Problem
+   operator complexity across AI runtime, stream, play, and monetization
+2. Why existing tools fall short
+   prompt-heavy, operations-thin, weak release discipline
+3. Product wedge
+   Alice + stream + arcade + SW4P as one operator stack
+4. What is already proven
+   deploy path, operator handbook, mastery coverage, technical/economic rail
+5. Proof assets
+   named artifacts only from `PROOF_ASSET_LIBRARY.md`
+6. Commercial path
+   creator/operator workflow, partner leverage, monetized activity
+7. Live vs operator-ready vs next
+   separate current proof from bounded roadmap
+8. Ask
+   strategic partner help, distribution, capital, or pilot alignment

--- a/program/PARTNER_VC_ONE_PAGER.md
+++ b/program/PARTNER_VC_ONE_PAGER.md
@@ -1,0 +1,40 @@
+# Partner / VC One-Pager
+
+## Wedge
+
+Render Network is building operator-grade infrastructure for AI-assisted
+streaming, play, and monetization.
+
+## Why this matters
+
+- most AI products stop at prompts and copilots
+- creator tooling fragments stream control, gameplay surfaces, and economic
+  actions
+- proof and release discipline are usually missing from the operator workflow
+
+## What is already real
+
+- Alice has a documented deploy and validation path
+- stream has a handbook, operator journey, runbook pack, and readiness memo
+- arcade has game-specific mastery and concrete progression/admin examples
+- SW4P has a chain register, operator handbook, and explicit Alice/555
+  integration doc
+
+## Why the stack is stronger together
+
+- Milady/Alice gives the operator runtime and interface
+- stream gives live operator control
+- arcade gives interactive play surfaces and mastery depth
+- SW4P gives the economic rail without outsourcing the operational truth
+
+## What is next
+
+- finish article drafts from the shipped roadmap
+- close the remaining arcade mastery gaps
+- capture dry-run proof for Alice setup and more release-evidence refreshes
+
+## Ask
+
+- partner: distribution, platforms, creator pilots, operational feedback
+- investor: support the operator-stack thesis and next-90 execution
+- program: help validate the proof-first launch loop with real targets

--- a/program/PROOF_ASSET_CONTRACT.md
+++ b/program/PROOF_ASSET_CONTRACT.md
@@ -1,0 +1,35 @@
+# Proof Asset Contract
+
+Every outward-facing claim must resolve to a reusable proof asset with explicit
+metadata.
+
+## Required metadata
+
+- `claim`
+  The statement this artifact supports.
+- `audience`
+  The consumer of the claim.
+- `artifact_type`
+  One of: `runbook`, `audit`, `screenshot`, `demo_clip`, `test_report`,
+  `matrix`, `memo`, `deck`, `one_pager`.
+- `source_repo_path`
+  Repo-relative or workspace-relative source path.
+- `date`
+  The artifact date in `YYYY-MM-DD`.
+- `reusability`
+  One of: `single_use`, `campaign_reusable`, `evergreen`.
+
+## Optional metadata
+
+- `dependencies`
+- `owner`
+- `review_status`
+- `claim_strength`
+  One of: `direct`, `supporting`, `contextual`.
+
+## Acceptance rules
+
+1. No proof asset can point at an undocumented black box.
+2. Time-sensitive assets must carry a date.
+3. A public narrative artifact must cite at least one `direct` proof asset.
+4. A partner or investor artifact must cite operator truth before market framing.

--- a/program/PROOF_ASSET_LIBRARY.md
+++ b/program/PROOF_ASSET_LIBRARY.md
@@ -1,0 +1,24 @@
+# Proof Asset Library
+
+This is the reusable evidence index for founder narrative, partner materials,
+public progress, and release-readiness claims.
+
+## Seed assets
+
+| Claim | Audience | Artifact type | Source repo/path | Date | Reusability |
+| --- | --- | --- | --- | --- | --- |
+| Alice has a real deploy path with explicit fallbacks and validation gates | operator, partner | audit / runbook | `555-bot/docs/ALICE_CURRENT_DEPLOYMENT_TECHNIQUE_AUDIT_2026-02-28.md` | 2026-02-28 | campaign_reusable |
+| Alice deployment can be executed by an operator without GitHub Actions | operator | runbook | `555-bot/docs/ALICE_WEBHOOK_DEPLOYMENT_RUNBOOK.md` | 2026-03-25 | evergreen |
+| Alice and Five55 surface parity is reviewed against explicit criteria | founder, partner | matrix | `milaidy/docs/FIVE55_ALICE_PARITY_MATRIX.md` | 2026-03-25 | campaign_reusable |
+| Stream runtime/operator work has evidence-backed acceptance coverage | founder, partner | test report | `555stream/PHASE7_UNIFIED_ACCEPTANCE_CLOSURE_2026-02-19_POST_REMEDIATION.md` | 2026-02-19 | campaign_reusable |
+| Stream operational evidence is collected and indexed | founder, partner, reviewer | evidence index | `555stream/ECOSYSTEM_EVIDENCE_INDEX.md` | 2026-03-25 | evergreen |
+| Arcade mastery exists as real, game-specific operator material | founder, operator | dossier set | `arcade-plugin/src/mastery/dossiers/` | 2026-03-08 | campaign_reusable |
+| SW4P has formal security, ops, and funding-grade technical documentation | partner, investor | whitepaper / audit set | `sw4p/docs/funding/SW4P_Technical_Whitepaper.md` | 2026-03-25 | campaign_reusable |
+| SW4P security posture is documented at the protocol level | partner, reviewer | threat model | `sw4p/docs/THREAT_MODEL.md` | 2026-03-25 | evergreen |
+
+## Promotion rules
+
+- Promote a dated artifact into evergreen docs only after it has been normalized
+  into an operator or public document.
+- Keep the original dated artifact as evidence.
+- When a claim weakens, demote the proof asset instead of silently deleting it.

--- a/program/README.md
+++ b/program/README.md
@@ -59,7 +59,9 @@ define how documentation work is scoped, written, evidenced, and closed across:
 
 1. Tickets are the unit of execution and acceptance.
 2. Repo-local documentation remains canonical.
-3. Public narrative is derived from operator truth and proof assets.
-4. No doc ticket closes without evidence links.
-5. Recurring/cadence tickets close only when the template exists and the first
+3. Board status must reflect default-branch or agreed canonical-branch reality,
+   not the existence of work on a topic branch.
+4. Public narrative is derived from operator truth and proof assets.
+5. No doc ticket closes without evidence links.
+6. Recurring/cadence tickets close only when the template exists and the first
    real artifact has shipped.

--- a/program/README.md
+++ b/program/README.md
@@ -32,6 +32,8 @@ define how documentation work is scoped, written, evidenced, and closed across:
   public, partner, and investor outputs.
 - `ARTICLE_SERIES_ROADMAP.md`
   The proof-backed article sequence.
+- `articles/`
+  The first shipped article drafts linked from the roadmap.
 - `PARTNER_VC_NARRATIVE.md`
   The concise positioning framework for partner and investor materials.
 - `PARTNER_VC_ONE_PAGER.md`
@@ -42,6 +44,8 @@ define how documentation work is scoped, written, evidenced, and closed across:
   Proof-backed outreach drafts for partners, investors, and programs.
 - `TARGET_DOSSIER_TEMPLATE.md`
   The one-page dossier template for specific targets and programs.
+- `dossiers/`
+  The live target-specific dossiers derived from the template.
 - `CATEGORY_DECK_BRIEF.md`
   The current category-deck spine and proof expectations.
 - `LAUNCH_STRATEGY_AND_NEXT_90.md`

--- a/program/README.md
+++ b/program/README.md
@@ -1,0 +1,61 @@
+# Documentation Program Canon
+
+This directory is the internal operating layer for the documentation program.
+
+The public Mintlify site remains the curated outward-facing surface. These files
+define how documentation work is scoped, written, evidenced, and closed across:
+
+- `Render-Network-OS/docs`
+- `Render-Network-OS/555-bot`
+- `rndrntwrk/milaidy`
+- `Render-Network-OS/stream` and `rndrntwrk/stream-plugin`
+- `rndrntwrk/555-arcade-plugin`
+- `rndrntwrk/sw4p-pro` and `sw4p`
+
+## What lives here
+
+- `ISSUE_BRIEF_STANDARD.md`
+  The canonical GitHub issue body format for documentation and brand-positioning
+  tickets.
+- `OPERATOR_DOC_CONTRACT.md`
+  The required shape for operator-facing docs, runbooks, and recovery guides.
+- `PROOF_ASSET_CONTRACT.md`
+  The metadata contract for any artifact used to support a public or partner
+  claim.
+- `SOURCE_REGISTER.md`
+  The system-of-record map for where claims, procedures, and product truth come
+  from.
+- `PROOF_ASSET_LIBRARY.md`
+  The index of reusable evidence by audience and claim.
+- `COMMUNICATION_OPERATING_SYSTEM.md`
+  The cadence system and the rules for turning finished operator work into
+  public, partner, and investor outputs.
+- `ARTICLE_SERIES_ROADMAP.md`
+  The proof-backed article sequence.
+- `PARTNER_VC_NARRATIVE.md`
+  The concise positioning framework for partner and investor materials.
+- `PARTNER_VC_ONE_PAGER.md`
+  The short-form external brief derived from the proof-backed narrative.
+- `LIGHTWEIGHT_DATA_ROOM.md`
+  The minimum diligence room and link set for serious partner/investor review.
+- `OUTREACH_MESSAGES.md`
+  Proof-backed outreach drafts for partners, investors, and programs.
+- `TARGET_DOSSIER_TEMPLATE.md`
+  The one-page dossier template for specific targets and programs.
+- `CATEGORY_DECK_BRIEF.md`
+  The current category-deck spine and proof expectations.
+- `LAUNCH_STRATEGY_AND_NEXT_90.md`
+  The launch type, launch bar, post-launch loop, and next-90 plan.
+- `EXPLICIT_OVERLAP_THESIS.md`
+  The rule for how adjacent products support the main 555 thesis.
+- `artifacts/`
+  First-cycle shipped artifacts for recurring communication tickets.
+
+## Operating rules
+
+1. Tickets are the unit of execution and acceptance.
+2. Repo-local documentation remains canonical.
+3. Public narrative is derived from operator truth and proof assets.
+4. No doc ticket closes without evidence links.
+5. Recurring/cadence tickets close only when the template exists and the first
+   real artifact has shipped.

--- a/program/SOURCE_REGISTER.md
+++ b/program/SOURCE_REGISTER.md
@@ -1,0 +1,22 @@
+# Source Register
+
+This file defines where canonical truth lives for each major documentation
+domain.
+
+| Domain | Canonical sources | Use for | Refresh rule |
+| --- | --- | --- | --- |
+| Public product narrative | `render_hub/docs/*` public pages | public site, partner summaries | refresh when product claims change |
+| Alice / deployer operations | `555-bot/docs/*`, `555-bot/alice_knowledge/*`, `milaidy/docs/ops/*`, `milaidy/knowledge/*` | setup, deploy, runtime, boundary docs | refresh on deploy/runtime contract change |
+| Alice product/operator behavior | `milaidy/docs/*`, `milaidy/knowledge/*` | install, config, operator flows, eval/safety | refresh on UX or runtime lifecycle change |
+| Stream operator truth | `stream-plugin/docs/*`, `555stream/*evidence*`, `555stream/*acceptance*` | setup, go-live, approvals, release readiness | refresh on operator action or runtime parity change |
+| Arcade operator truth | `arcade-plugin/docs/*`, `arcade-plugin/src/mastery/dossiers/*` | gameplay, progression, mastery, release docs | refresh on catalog, actions, or progression semantics change |
+| SW4P technical truth | `sw4p/docs/*`, `sw4p/docs/internal/*`, `sw4p/docs/funding/*` | routes, ops, security, integration, economics | refresh on chain support, fee model, or control changes |
+| Proof assets | evidence indices, audits, test packets, screenshots, clips, memos | public claims, partner decks, release readiness | refresh when underlying proof ages out or product changes |
+
+## Rules
+
+- If multiple repos discuss the same flow, the source register decides the
+  canonical owner.
+- Mirrors can summarize but must link back to the canonical source.
+- Dated audits are evidence, not default evergreen docs, unless promoted into an
+  evergreen document.

--- a/program/TARGET_DOSSIER_TEMPLATE.md
+++ b/program/TARGET_DOSSIER_TEMPLATE.md
@@ -1,0 +1,34 @@
+# Target Dossier Template
+
+## Target
+
+- name:
+- type: partner / platform / investor / accelerator / pilot target
+- why they matter now:
+
+## Fit hypothesis
+
+- which part of the stack is most relevant:
+- what proof matters most to this target:
+- what would make this a strong next step:
+
+## Proof to send
+
+- proof asset 1:
+- proof asset 2:
+- proof asset 3:
+
+## Risks / objections
+
+- likely objection:
+- evidence-backed answer:
+
+## Ask
+
+- intro / pilot / diligence review / feedback / distribution / capital
+
+## Next action
+
+- owner:
+- date:
+- follow-up artifact:

--- a/program/articles/why-ai-agents-need-runbooks.md
+++ b/program/articles/why-ai-agents-need-runbooks.md
@@ -1,0 +1,83 @@
+# Why AI Agents Need Runbooks, Not Just Prompts
+
+AI agents fail in the exact places operators fail: handoffs, state drift,
+approvals, recovery, and unclear ownership. A better prompt does not solve any
+of those problems. What solves them is operator discipline made explicit in
+runbooks, recovery rules, and proof-backed acceptance criteria.
+
+The useful distinction is simple. A prompt tells an agent what tone or role to
+take. A runbook tells an operator and a system what to do when conditions
+change, when approvals are required, what evidence counts as success, and how
+to recover when the happy path fails. If an AI product claims to be production
+ready without that layer, it is still a demo.
+
+Alice is only credible as an operating system component because the work is
+being reduced to explicit operator material:
+
+- deploy truth is anchored in
+  `555-bot/docs/ALICE_WEBHOOK_DEPLOYMENT_RUNBOOK.md` and
+  `555-bot/docs/ALICE_DEPLOYMENT_OPERATOR_QUICK_RUNBOOK.md`
+- runtime/deployer boundaries are anchored in
+  `milaidy/docs/operators/alice-system-boundary.md`
+- first-use operator setup is anchored in
+  `milaidy/docs/operators/alice-operator-bootstrap.md`
+- lifecycle language is anchored in
+  `milaidy/docs/operators/stack-lifecycle-glossary.md`
+- stream and SW4P operating surfaces are anchored in
+  `stream-plugin/docs/OPERATOR_HANDBOOK_INDEX.md` and
+  `sw4p/docs/operations/operator-handbook.mdx`
+
+That stack matters because the real failure mode in AI operations is not model
+intelligence. It is undocumented state. Teams forget which deploy path is
+canonical, which approval is required, which fallback is allowed, which proof
+artifact backs a public claim, and which repo actually owns the truth. Once the
+system crosses repos and products, memory stops being a valid control plane.
+
+Runbooks create four advantages that prompts alone cannot:
+
+## 1. Ownership becomes explicit
+
+When boundary docs are correct, the operator knows whether a problem belongs to
+runtime, deployer, stream, arcade, or SW4P. That shortens recovery time and
+prevents two bad patterns: silent ownership gaps and duplicated fixes in the
+wrong layer.
+
+## 2. Recovery becomes real
+
+A fallback path only exists if someone can execute it under pressure. A prompt
+can describe a fallback. A runbook defines the trigger, the steps, the evidence
+to capture, and the condition for returning to normal operation.
+
+## 3. Public claims can be audited
+
+If the only support for a claim is "the agent can do this," the claim is weak.
+If the claim links to a runbook, a validation checklist, and a proof asset, it
+becomes reviewable by operators, partners, and investors.
+
+## 4. Improvement stops being anecdotal
+
+Prompt iteration is easy to overfit to a demo. Runbook-backed systems force the
+team to ask harder questions: what is the required evidence, where are the
+failure modes, what is still manual, and what remains unsafe to claim?
+
+This is why the right framing for Alice is not "smart chatbot" or even "AI
+agent." The more accurate framing is operator system. The model matters, but it
+is only one component inside a larger operating surface made of approvals,
+state, recovery, and evidence.
+
+## Proof anchors
+
+- Alice has an explicit deploy path with fallback and validation:
+  `555-bot/docs/ALICE_CURRENT_DEPLOYMENT_TECHNIQUE_AUDIT_2026-02-28.md`
+- Alice deployment is executable without relying on one opaque CI path:
+  `555-bot/docs/ALICE_WEBHOOK_DEPLOYMENT_RUNBOOK.md`
+- Stream operations are documented as an operator surface, not a novelty flow:
+  `stream-plugin/docs/OPERATOR_HANDBOOK_INDEX.md`
+- SW4P operating truth is documented with chain and operator constraints:
+  `sw4p/docs/operations/chain-register.mdx`
+
+## Close note
+
+This draft is intentionally bounded. It is ready to support `docs#111` because
+it is linked from the roadmap, grounded in named proof assets, and phrased only
+at the strength the current evidence supports.

--- a/program/artifacts/CATEGORY_DECK_REFRESH_2026-03-25.md
+++ b/program/artifacts/CATEGORY_DECK_REFRESH_2026-03-25.md
@@ -1,0 +1,30 @@
+# Category Deck Refresh 2026-03-25
+
+## System thesis
+
+Render Network is building operator-grade infrastructure for AI-assisted
+streaming, play, and monetization.
+
+## Product proofs
+
+- Alice deploy and boundary docs are explicit
+- stream has a real handbook, journey, and runbook pack
+- arcade has mastery material and progression/admin examples
+- SW4P has chain, integration, and readiness docs
+
+## Economic flywheel
+
+Operational surfaces become more valuable when they can route value, not just
+content. SW4P makes that legible without turning the rest of the stack into
+wallet-first products.
+
+## Opportunity map
+
+- creator/operator workflows
+- proof-first BD and pilot conversations
+- partner programs where the operator wedge matters
+
+## Ask
+
+- partners: pilots, distribution, creator workflow pressure-testing
+- investors: support for the operator-stack thesis and next-90 execution

--- a/program/artifacts/FOUNDER_EOD_2026-03-25.md
+++ b/program/artifacts/FOUNDER_EOD_2026-03-25.md
@@ -1,0 +1,23 @@
+# Founder EOD 2026-03-25
+
+## What shipped
+
+- documentation program canon established in `program/`
+- Alice/deployer root identity and bootstrap docs added
+- stream operator handbook index, mastery lane, and readiness memo added
+- arcade program index, mastery index, and progression/admin examples added
+- SW4P chain register, operator handbook, integration page, and readiness memo
+  added
+
+## What is now clearer
+
+- repo-local canon vs public surface
+- Milady vs Alice vs 555-bot ownership
+- stream and arcade operator entrypoints
+- SW4P operator reading path
+
+## What remains open
+
+- GitHub issue-body normalization and board moves
+- current-cycle evidence refresh in stream and SW4P
+- public-facing narrative sync for the docs repo

--- a/program/artifacts/FOUNDER_OPERATING_MEMO_2026-03-25.md
+++ b/program/artifacts/FOUNDER_OPERATING_MEMO_2026-03-25.md
@@ -1,0 +1,34 @@
+# Founder Operating Memo 2026-03-25
+
+## Executive summary
+
+The documentation program is now writing against explicit standards instead of
+free-form ticket titles. Repo-local operator canon has been established or
+indexed in the main product repos, which reduces the risk of narrative running
+ahead of proof.
+
+## Repo status
+
+- `Render-Network-OS/docs`
+  standards, source register, proof asset library, and comms OS are now defined
+- `milaidy` / `555-bot`
+  boundary docs, corpus ownership, and operator bootstrap are now explicit
+- `stream-plugin`
+  operator entrypoint, mastery lane, and readiness memo now exist
+- `555-arcade-plugin`
+  program index, mastery index, and advanced progression examples now exist
+- `sw4p`
+  operator entrypoint, chain register, Alice/555 integration boundary, and
+  readiness memo now exist
+
+## Immediate blockers
+
+- ticket bodies and board statuses still need direct GitHub sync
+- some readiness claims still depend on dated evidence packets that need a
+  current-cycle refresh
+
+## Next actions
+
+1. normalize GitHub issue bodies to the new brief standard
+2. attach these repo-local doc outputs as evidence
+3. move tickets to `In Progress` or `Done` based on shipped artifacts

--- a/program/artifacts/INVESTOR_UPDATE_2026-03-25.md
+++ b/program/artifacts/INVESTOR_UPDATE_2026-03-25.md
@@ -1,0 +1,24 @@
+# Investor Update 2026-03-25
+
+## This cycle
+
+We invested in documentation and proof infrastructure that reduces execution
+risk across the stack.
+
+## Why this matters
+
+- the operator path is clearer
+- the founder story is more defensible
+- the release surface is less dependent on memory and ad hoc explanations
+
+## Concrete progress
+
+- standardized issue-brief, operator-doc, and proof-asset contracts
+- formalized source-of-truth mapping across repos
+- added repo-local indexes for Alice, stream, arcade, and SW4P
+- created first-cycle cadence artifacts from the new system
+
+## Current caution
+
+Some product surfaces still need a current-cycle evidence refresh before their
+strongest claims should be treated as launch-ready.

--- a/program/artifacts/PARTNER_MINI_BRIEF_2026-03-25.md
+++ b/program/artifacts/PARTNER_MINI_BRIEF_2026-03-25.md
@@ -1,0 +1,24 @@
+# Partner Mini-Brief 2026-03-25
+
+## What Render Network is proving
+
+Render Network is not shipping disconnected demos. It is assembling an
+operator-grade stack where AI runtime, streaming, gameplay, monetization, and
+cross-chain transfer surfaces can be reasoned about together.
+
+## Current proof points
+
+- Alice deploy and runtime validation are documented as an operator path
+- stream operations are documented as a real handbook, not an aspirational flow
+- arcade mastery exists as game-specific dossiers
+- SW4P has technical, security, and operator documentation beyond a landing page
+
+## Why this matters for partners
+
+Partnerships are stronger when the operator path is real, repeatable, and
+reviewable. That lowers demo risk, onboarding risk, and claims risk.
+
+## What is still open
+
+Current-cycle evidence refresh is still required in some release-readiness
+surfaces before broader outward claims should be made.

--- a/program/artifacts/PUBLIC_BUILD_LOG_2026-03-25.md
+++ b/program/artifacts/PUBLIC_BUILD_LOG_2026-03-25.md
@@ -1,0 +1,25 @@
+# Public Build Log 2026-03-25
+
+This cycle focused on tightening the stack around operator truth.
+
+What changed:
+
+- Alice now has a cleaner operator bootstrap and clearer boundary docs between
+  Milady, Alice, and the deployer
+- the stream operator surface now has one handbook entrypoint, a mastery lane,
+  and a release-readiness memo
+- the arcade operator surface now has a unified program index and a full-catalog
+  mastery tracker
+- SW4P now has an operator handbook, chain register, and explicit integration
+  boundary back to the rest of the stack
+
+What this means:
+
+- fewer docs depend on founder memory
+- more claims can be traced back to specific runbooks, matrices, and evidence
+- the public story is increasingly derived from the real operator surface
+
+What remains bounded:
+
+- some release claims still need current-cycle evidence refresh before they
+  should be marketed as fully closed

--- a/program/dossiers/README.md
+++ b/program/dossiers/README.md
@@ -1,0 +1,7 @@
+# Active Target Dossiers
+
+These are real instances derived from `../TARGET_DOSSIER_TEMPLATE.md`.
+
+- `colosseum-eternal.md`
+- `arbitrum-gaming-ventures.md`
+- `creator-operator-design-partners.md`

--- a/program/dossiers/arbitrum-gaming-ventures.md
+++ b/program/dossiers/arbitrum-gaming-ventures.md
@@ -1,0 +1,44 @@
+# Target Dossier: Arbitrum Gaming Ventures
+
+## Target
+
+- name: Arbitrum Gaming Ventures
+- type: investor / platform fund
+- why they matter now: They care about repeatable gaming infrastructure, live
+  traction narratives, and category-level positioning around onchain
+  entertainment.
+
+## Fit hypothesis
+
+- which part of the stack is most relevant: the overlap between arcade, stream,
+  and SW4P as one operating stack
+- what proof matters most to this target: explicit overlap thesis, partner/VC
+  narrative, and technical proof that the stack is more than isolated features
+- what would make this a strong next step: a concise package that shows the
+  stack as operator software with monetization rails, not just content tools
+
+## Proof to send
+
+- proof asset 1: `program/EXPLICIT_OVERLAP_THESIS.md`
+- proof asset 2: `program/PARTNER_VC_NARRATIVE.md`
+- proof asset 3: `sw4p/docs/operations/alice-and-555.mdx`
+
+## Risks / objections
+
+- likely objection: The story may read as several adjacent products instead of
+  one coherent category thesis.
+- evidence-backed answer: The overlap thesis plus the Alice/stream/arcade/SW4P
+  integration docs give a concrete operator and monetization narrative across
+  the stack.
+
+## Ask
+
+- intro / pilot / diligence review / feedback / distribution / capital:
+  diligence review and thesis feedback
+
+## Next action
+
+- owner: founder
+- date: next investor packaging cycle after the docs program branch lands
+- follow-up artifact: a concise investor room packet built from the category
+  deck, one-pager, and overlap thesis

--- a/program/dossiers/colosseum-eternal.md
+++ b/program/dossiers/colosseum-eternal.md
@@ -1,0 +1,46 @@
+# Target Dossier: Colosseum Eternal
+
+## Target
+
+- name: Colosseum Eternal
+- type: platform / program
+- why they matter now: They are aligned with onchain gaming distribution, live
+  operator workflows, and evidence-backed product slices instead of generic AI
+  positioning.
+
+## Fit hypothesis
+
+- which part of the stack is most relevant: 555 Arcade plus stream-backed proof
+  of playable, operator-managed game loops
+- what proof matters most to this target: game-specific mastery dossiers,
+  operator flow clarity, and evidence that the stack can package a competition
+  or activation loop
+- what would make this a strong next step: a thin-slice demo showing game
+  mastery, stream visibility, and a concrete operator reading path
+
+## Proof to send
+
+- proof asset 1: `arcade-plugin/docs/PROGRAM_INDEX.md`
+- proof asset 2: `arcade-plugin/docs/MASTERY_INDEX.md`
+- proof asset 3: `stream-plugin/docs/OPERATOR_HANDBOOK_INDEX.md`
+
+## Risks / objections
+
+- likely objection: The stack is broad, but the program may question whether
+  the game loop is packaged tightly enough for a focused activation.
+- evidence-backed answer: The operator path, mastery dossiers, and stream
+  handbook now reduce the stack to a bounded, demonstrable loop rather than a
+  vague platform claim.
+
+## Ask
+
+- intro / pilot / diligence review / feedback / distribution / capital:
+  feedback plus pilot-style review for an operator-led onchain competition
+  slice
+
+## Next action
+
+- owner: founder
+- date: next outbound wave after `docs#34` merge
+- follow-up artifact: a one-page outbound packet with the arcade proof and
+  stream operator path

--- a/program/dossiers/creator-operator-design-partners.md
+++ b/program/dossiers/creator-operator-design-partners.md
@@ -1,0 +1,43 @@
+# Target Dossier: Creator-Operator Design Partners
+
+## Target
+
+- name: Creator-Operator Design Partners
+- type: pilot target
+- why they matter now: The fastest way to harden the stack is to work with
+  operators who feel the pain of live setup, approval, recovery, and monetized
+  loops.
+
+## Fit hypothesis
+
+- which part of the stack is most relevant: Alice bootstrap, stream operator
+  handbook, and SW4P payout/onboarding documentation
+- what proof matters most to this target: setup clarity, live-operation
+  recovery, and honest documentation of what is manual versus productized
+- what would make this a strong next step: one guided operator walkthrough with
+  a bounded proof packet and explicit support expectations
+
+## Proof to send
+
+- proof asset 1: `milaidy/docs/operators/alice-operator-bootstrap.md`
+- proof asset 2: `stream-plugin/docs/RUNBOOK_PACK.md`
+- proof asset 3: `program/PARTNER_VC_ONE_PAGER.md`
+
+## Risks / objections
+
+- likely objection: The operator may worry the stack still requires founder
+  memory to use successfully.
+- evidence-backed answer: The docs program now has explicit bootstrap,
+  runbook, and proof-backed reading paths intended to remove that dependency.
+
+## Ask
+
+- intro / pilot / diligence review / feedback / distribution / capital:
+  pilot and workflow feedback
+
+## Next action
+
+- owner: founder
+- date: after `milaidy#19` proof capture
+- follow-up artifact: a guided pilot packet with screenshots, runbooks, and
+  support boundaries


### PR DESCRIPTION
## Summary
- add the recovery rule that board status must reflect default-branch or agreed canonical-branch reality
- update the issue brief standard so close conditions require merged, linked evidence rather than topic-branch existence

## Why
The recovery pass exposed stale done statuses that were based on pushed docs branches rather than default-branch truth. This makes the closure bar explicit in the program canon.