### PR TITLE
docs(program): codify default-branch board truth rule

### DIFF
--- a/program/ISSUE_BRIEF_STANDARD.md
+++ b/program/ISSUE_BRIEF_STANDARD.md
@@ -57,6 +57,9 @@ Examples:
 ### Close condition
 Define the single sentence that makes the ticket closable.
 
+The close condition must assume default-branch or agreed canonical-branch
+reality. A ticket is not done only because a draft or topic branch exists.
+
 ## Example skeleton
 
 ```md
@@ -96,5 +99,5 @@ Create the canonical stream operator handbook for setup, go-live, recovery, and 
 - Preview/build output
 
 ## Close condition
-The owning repo has one canonical operator entrypoint and the issue contains evidence links to it.
+The owning repo has one canonical operator entrypoint on the default or agreed canonical branch, and the issue contains evidence links to it.
 ```

--- a/program/README.md
+++ b/program/README.md
@@ -59,7 +59,9 @@ define how documentation work is scoped, written, evidenced, and closed across:
 
 1. Tickets are the unit of execution and acceptance.
 2. Repo-local documentation remains canonical.
-3. Public narrative is derived from operator truth and proof assets.
-4. No doc ticket closes without evidence links.
-5. Recurring/cadence tickets close only when the template exists and the first
+3. Board status must reflect default-branch or agreed canonical-branch reality,
+   not the existence of work on a topic branch.
+4. Public narrative is derived from operator truth and proof assets.
+5. No doc ticket closes without evidence links.
+6. Recurring/cadence tickets close only when the template exists and the first
    real artifact has shipped.


### PR DESCRIPTION
## Summary
- add the recovery rule that board status must reflect default-branch or agreed canonical-branch reality
- update the issue brief standard so close conditions require merged, linked evidence rather than topic-branch existence

## Why
The recovery pass exposed stale done statuses that were based on pushed docs branches rather than default-branch truth. This makes the closure bar explicit in the program canon.