### PR TITLE
docs: add PR size review guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+- What changed?
+
+## Related issue
+- Closes #
+
+## PR size
+- Type: `docs-only` or `repo logic / workflow`
+- Target: docs PRs `< 1000` changed lines, repo logic / workflow PRs `< 400` changed lines
+- If this exceeds the target, explain why the change could not be split smaller:
+
+## Validation
+- What did you check locally?
+
+## Reviewer notes
+- What should the reviewer pay special attention to?

--- a/.github/workflows/pr-size-warning.yml
+++ b/.github/workflows/pr-size-warning.yml
@@ -1,0 +1,138 @@
+name: PR Size Warning
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  warn-on-large-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Warn on oversized PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- docs-pr-size-warning -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const ignoredFiles = new Set([
+              'package-lock.json',
+              'pnpm-lock.yaml',
+              'yarn.lock',
+              'bun.lock',
+              'bun.lockb',
+            ]);
+
+            const docsExtensions = new Set([
+              '.md',
+              '.mdx',
+              '.txt',
+              '.png',
+              '.jpg',
+              '.jpeg',
+              '.gif',
+              '.svg',
+              '.webp',
+              '.avif',
+            ]);
+
+            function isDocsLike(filename) {
+              if (
+                filename.startsWith('.github/') ||
+                filename.startsWith('components/') ||
+                filename.startsWith('styles/')
+              ) {
+                return false;
+              }
+
+              const extension = filename.includes('.')
+                ? `.${filename.split('.').pop().toLowerCase()}`
+                : '';
+
+              return docsExtensions.has(extension);
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const effectiveFiles = files.filter((file) => !ignoredFiles.has(file.filename));
+            const changedLines = effectiveFiles.reduce(
+              (total, file) => total + file.additions + file.deletions,
+              0,
+            );
+            const docsOnly = effectiveFiles.every((file) => isDocsLike(file.filename));
+            const limit = docsOnly ? 1000 : 400;
+            const scopeLabel = docsOnly ? 'docs-only' : 'repo logic / workflow';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pull_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+
+            const summary = [
+              '## PR Size Review',
+              `- Scope: \`${scopeLabel}\``,
+              `- Effective changed lines: \`${changedLines}\``,
+              `- Guideline: \`< ${limit}\` changed lines`,
+            ].join('\n');
+
+            core.summary.addRaw(summary).write();
+
+            if (changedLines <= limit) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            const body = [
+              marker,
+              'This PR is above the review-size guideline.',
+              '',
+              `- Scope: \`${scopeLabel}\``,
+              `- Effective changed lines: \`${changedLines}\``,
+              `- Guideline: \`< ${limit}\` changed lines`,
+              '',
+              'Split the PR if possible, or explain in the PR body why the change must stay large.',
+              'This is advisory only and does not block merge.',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body,
+            });

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ We welcome contributions from the community! Here's how to get involved:
 4. **Submit a Pull Request**
    - Provide a clear description of changes
    - Reference any related issues
+   - Keep docs-only PRs under 1000 changed lines when possible
+   - Keep repo logic, workflow, config, and UI PRs under 400 changed lines
+   - If a PR exceeds the guideline, explain why it could not be split smaller
    - Wait for review and approval
 
 ### 📚 Content Guidelines

--- a/program/BRANCH_RULES.md
+++ b/program/BRANCH_RULES.md
@@ -1,0 +1,57 @@
+# Branch And PR Rules
+
+This file is the canonical review-scope rule for `Render-Network-OS/docs`.
+
+## Default-branch truth
+
+- Board status must reflect `main`, not a topic branch.
+- No docs ticket closes on draft work alone.
+- If a change is still waiting on review or merge, the ticket stays open.
+
+## PR size guideline
+
+PRs must stay small enough for one reviewer to understand the full change in one
+sitting.
+
+- Docs-only PRs should stay under `1000` changed lines.
+- Repo logic, workflow, config, or UI PRs should stay under `400` changed lines.
+- Lock files do not count toward the advisory threshold.
+
+For this repo, "repo logic, workflow, config, or UI" includes files such as:
+
+- `.github/**`
+- `components/**`
+- `styles/**`
+- `docs.json`
+- `package.json`
+- any script or config file that changes how docs are built or reviewed
+
+## If a PR exceeds the guideline
+
+- Split it when the work can be separated without hiding coupling.
+- If it cannot be split cleanly, explain why in the PR body.
+- Reviewer should explicitly acknowledge the exception before merge.
+
+Large one-time migrations are allowed only when the PR body explains:
+
+- why the change is coupled
+- why the current slice is the smallest reviewable unit
+- what the reviewer should focus on first
+
+## Reviewer expectation
+
+- Reviewer must be able to explain the full change after one pass through the
+  diff.
+- If that is not realistic, the PR is too large or the PR body is too weak.
+
+## Required PR body fields
+
+Every PR should include:
+
+- summary of change
+- related issue
+- PR size classification
+- validation performed
+- explicit reviewer notes
+
+Use the repo PR template as the default shape.

--- a/program/PR_SIZE_REVIEW_AUDIT_2026-04-10.md
+++ b/program/PR_SIZE_REVIEW_AUDIT_2026-04-10.md
@@ -1,0 +1,36 @@
+# PR Size Review Audit 2026-04-10
+
+This audit closes the review portion of `docs#86`.
+
+## Scope
+
+- Reviewed the most recent visible PR sample from `Render-Network-OS/docs`.
+- GitHub currently exposes four recent PRs in the active repo history, not ten,
+  so this audit uses the full available sample.
+
+## Guideline used
+
+- Docs-only PRs: `< 1000` changed lines
+- Repo logic / workflow / config / UI PRs: `< 400` changed lines
+
+## Recent PR sample
+
+| PR | Title | Scope | Changed lines | Files | Result | Notes |
+| --- | --- | --- | ---: | ---: | --- | --- |
+| #183 | `docs: QA-SYS-03 first weekly security review — assign owners, set due…` | docs-only | 368 | 10 | Pass | Reviewable in one sitting. |
+| #181 | `docs(program): codify default-branch board truth rule` | docs-only | 13 | 2 | Pass | Tight fix-up PR. |
+| #180 | `docs(program): codify default-branch board truth rule` | docs-only | 1108 | 27 | Exceeds guideline | Oversized draft; later replaced by smaller merged PR #181. |
+| #179 | `docs: land program canon, first article, and target dossiers` | docs-only | 1103 | 27 | Exceeds guideline | One-time canon bootstrap; should have carried an explicit large-PR justification. |
+
+## Result
+
+- 2 of 4 recent PRs fit the guideline cleanly.
+- 2 of 4 recent PRs exceeded the docs-only threshold.
+- The repo needs a standing warning surface so large PRs are called out before
+  merge instead of being normalized after the fact.
+
+## Landed controls
+
+- Canonical rule: `program/BRANCH_RULES.md`
+- PR template: `.github/PULL_REQUEST_TEMPLATE.md`
+- Non-blocking warning workflow: `.github/workflows/pr-size-warning.yml`

--- a/program/README.md
+++ b/program/README.md
@@ -17,6 +17,8 @@ define how documentation work is scoped, written, evidenced, and closed across:
 - `ISSUE_BRIEF_STANDARD.md`
   The canonical GitHub issue body format for documentation and brand-positioning
   tickets.
+- `BRANCH_RULES.md`
+  The canonical pull-request scope and review-size rules for this repo.
 - `OPERATOR_DOC_CONTRACT.md`
   The required shape for operator-facing docs, runbooks, and recovery guides.
 - `PROOF_ASSET_CONTRACT.md`


### PR DESCRIPTION
Closes #86

## Summary
- add a canonical PR size rule for the docs repo under program/
- add a PR template that forces size classification and reviewer notes
- add a non-blocking PR size warning workflow and a dated audit of recent PR sizes

## Validation
- git diff --check
- ruby YAML parse for .github/workflows/pr-size-warning.yml
