### PR TITLE
docs: add PR review-state guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,7 @@
 
 ## Reviewer notes
 - What should the reviewer pay special attention to?
+
+## Review state at merge
+- Explicit human review required before merge: `APPROVED` or `CHANGES_REQUESTED`
+- If branch protection is unavailable, add or update the PR review-state comment before merge so the outcome is not silent

--- a/.github/workflows/review-state-comment.yml
+++ b/.github/workflows/review-state-comment.yml
@@ -1,0 +1,105 @@
+name: PR Review State Comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-review-state-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update review state comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- docs-review-state-comment -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const latestByReviewer = new Map();
+
+            for (const review of reviews) {
+              if (review.user?.type === 'Bot') {
+                continue;
+              }
+
+              latestByReviewer.set(review.user.login, review);
+            }
+
+            const effectiveReviews = [...latestByReviewer.values()];
+            const approvals = effectiveReviews.filter((review) => review.state === 'APPROVED');
+            const changesRequested = effectiveReviews.filter(
+              (review) => review.state === 'CHANGES_REQUESTED',
+            );
+
+            let stateLine = '- Current state: no explicit human `APPROVED` or `CHANGES_REQUESTED` review yet';
+            let nextAction = '- Merge should wait until a reviewer leaves an explicit review state';
+
+            if (changesRequested.length > 0) {
+              stateLine = `- Current state: \`CHANGES_REQUESTED\` by ${changesRequested
+                .map((review) => `@${review.user.login}`)
+                .join(', ')}`;
+              nextAction =
+                '- Merge should pause until the requested changes are resolved and an approval is recorded';
+            } else if (approvals.length > 0) {
+              stateLine = `- Current state: \`APPROVED\` by ${approvals
+                .map((review) => `@${review.user.login}`)
+                .join(', ')}`;
+              nextAction = '- Merge can proceed if the approval still matches the current diff';
+            }
+
+            const body = [
+              marker,
+              '## PR Review State',
+              '',
+              stateLine,
+              nextAction,
+              '',
+              'This is advisory. It exists so docs PRs do not merge with a silent review state while branch protection is unavailable.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pull_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ We welcome contributions from the community! Here's how to get involved:
    - Keep docs-only PRs under 1000 changed lines when possible
    - Keep repo logic, workflow, config, and UI PRs under 400 changed lines
    - If a PR exceeds the guideline, explain why it could not be split smaller
+   - Do not merge silently; every merge needs an explicit review state
    - Wait for review and approval
 
 ### 📚 Content Guidelines

--- a/program/BRANCH_RULES.md
+++ b/program/BRANCH_RULES.md
@@ -44,6 +44,16 @@ Large one-time migrations are allowed only when the PR body explains:
   diff.
 - If that is not realistic, the PR is too large or the PR body is too weak.
 
+## No silent merges
+
+- Do not merge a PR with only comments or no recorded review state.
+- Reviewer must use an explicit GitHub review state: `APPROVED` or
+  `CHANGES_REQUESTED`.
+- Bot comments do not count as the final review decision.
+- Until branch protection requires reviews automatically, the PR review-state
+  comment must be updated before merge so the current review state is visible on
+  the PR itself.
+
 ## Required PR body fields
 
 Every PR should include:
@@ -53,5 +63,7 @@ Every PR should include:
 - PR size classification
 - validation performed
 - explicit reviewer notes
+- review-state note if the branch is being merged without required-review
+  enforcement
 
 Use the repo PR template as the default shape.

--- a/program/PR_REVIEW_STATE_AUDIT_2026-04-10.md
+++ b/program/PR_REVIEW_STATE_AUDIT_2026-04-10.md
@@ -1,0 +1,41 @@
+# PR Review State Audit 2026-04-10
+
+This audit records the current baseline for `docs#87`.
+
+## Scope
+
+- Reviewed the most recent visible PR sample from `Render-Network-OS/docs`.
+- Verified the current branch-protection state for `main`.
+
+## Branch protection state
+
+- `main` is currently **not protected**.
+- GitHub API result on 2026-04-10: `Branch not protected` from
+  `repos/Render-Network-OS/docs/branches/main/protection`.
+
+That means required approving reviews are still blocked on an admin branch
+protection change, not on missing documentation.
+
+## Recent PR review-state sample
+
+| PR | State | Review state seen | Result | Notes |
+| --- | --- | --- | --- | --- |
+| #184 | merged | none | Silent merge | Merged before this guardrail landed. |
+| #183 | open | none | Incomplete | No explicit human review state yet. |
+| #181 | merged | none | Silent merge | Merged without explicit approve/request-changes review. |
+| #180 | closed | `COMMENTED` bot review only | Incomplete | Not merged, but still lacked explicit human review state. |
+| #179 | merged | `COMMENTED` bot review only | Silent merge | Bot comment existed, but no explicit human review state. |
+
+## Result
+
+- The repo needed a standing PR-level review-state comment because silent merges
+  were still possible and visible in the recent sample.
+- Required approving reviews remain a follow-up admin change once branch
+  protection is enabled.
+
+## Landed controls
+
+- Rule update in `program/BRANCH_RULES.md`
+- PR template requirement in `.github/PULL_REQUEST_TEMPLATE.md`
+- Advisory PR review-state comment workflow in
+  `.github/workflows/review-state-comment.yml`

--- a/program/README.md
+++ b/program/README.md
@@ -19,6 +19,8 @@ define how documentation work is scoped, written, evidenced, and closed across:
   tickets.
 - `BRANCH_RULES.md`
   The canonical pull-request scope and review-size rules for this repo.
+- `PR_REVIEW_STATE_AUDIT_2026-04-10.md`
+  The dated baseline audit for explicit reviewer state vs silent merges.
 - `OPERATOR_DOC_CONTRACT.md`
   The required shape for operator-facing docs, runbooks, and recovery guides.
 - `PROOF_ASSET_CONTRACT.md`


### PR DESCRIPTION
Refs #87

## Summary
- document the no-silent-merge rule in the canonical branch rules
- add an advisory PR review-state comment workflow so every PR shows its current explicit review state
- add a dated audit of recent docs PRs and the current branch-protection blocker

## Validation
- git diff --check
- ruby YAML parse for .github/workflows/pr-size-warning.yml
- ruby YAML parse for .github/workflows/review-state-comment.yml

## Remaining blocker
- main is still unprotected, so required approving reviews remain an admin branch-protection follow-up
