### PR TITLE
docs: add founder proof folder

### DIFF
--- a/program/LIGHTWEIGHT_DATA_ROOM.md
+++ b/program/LIGHTWEIGHT_DATA_ROOM.md
@@ -12,6 +12,7 @@ This is the minimum diligence room for partner and investor conversations.
 | Narrative | partner/VC narrative | `PARTNER_VC_NARRATIVE.md` |
 | One-pager | concise external brief | `PARTNER_VC_ONE_PAGER.md` |
 | Proof | reusable proof asset library | `PROOF_ASSET_LIBRARY.md` |
+| Founder proof folder | fast founder-facing proof index | `founder-proof/INDEX.md` |
 | Comms system | recurring founder/public/partner/investor outputs | `COMMUNICATION_OPERATING_SYSTEM.md` |
 | Launch strategy | launch bar and next-90 plan | `LAUNCH_STRATEGY_AND_NEXT_90.md` |
 | Source register | canonical documentation ownership | `SOURCE_REGISTER.md` |

--- a/program/PROOF_ASSET_LIBRARY.md
+++ b/program/PROOF_ASSET_LIBRARY.md
@@ -3,6 +3,10 @@
 This is the reusable evidence index for founder narrative, partner materials,
 public progress, and release-readiness claims.
 
+For the fastest founder-facing reuse path, start with
+`program/founder-proof/INDEX.md` and use this file as the deeper reusable
+library behind it.
+
 ## Seed assets
 
 | Claim | Audience | Artifact type | Source repo/path | Date | Reusability |

--- a/program/README.md
+++ b/program/README.md
@@ -31,6 +31,9 @@ define how documentation work is scoped, written, evidenced, and closed across:
   from.
 - `PROOF_ASSET_LIBRARY.md`
   The index of reusable evidence by audience and claim.
+- `founder-proof/`
+  The fast-retrieval founder-facing proof folder built on top of the proof
+  asset library.
 - `COMMUNICATION_OPERATING_SYSTEM.md`
   The cadence system and the rules for turning finished operator work into
   public, partner, and investor outputs.

--- a/program/founder-proof/INDEX.md
+++ b/program/founder-proof/INDEX.md
@@ -1,0 +1,58 @@
+# Founder Proof Index
+
+This is the founder-facing proof folder for `docs#113`.
+
+## Core narrative proof
+
+| Category | Asset | Use | Source repo/path | Freshness |
+| --- | --- | --- | --- | --- |
+| Thesis | Partner / VC one-pager | short external explanation of the stack and wedge | `program/PARTNER_VC_ONE_PAGER.md` | 2026-03-25 |
+| Thesis | Partner / VC narrative | longer founder/investor story with stronger claim framing | `program/PARTNER_VC_NARRATIVE.md` | 2026-03-25 |
+| Thesis | Explicit overlap thesis | explains why Alice, stream, arcade, and SW4P belong together | `program/EXPLICIT_OVERLAP_THESIS.md` | 2026-03-25 |
+| Diligence | Lightweight data room | fastest diligence-room bundle for serious conversations | `program/LIGHTWEIGHT_DATA_ROOM.md` | 2026-03-25 |
+
+## Founder packets and reusable updates
+
+| Category | Asset | Use | Source repo/path | Freshness |
+| --- | --- | --- | --- | --- |
+| Founder memo | Founder operating memo | weekly founder readout with status, blockers, and system evidence | `program/artifacts/FOUNDER_OPERATING_MEMO_2026-03-25.md` | 2026-03-25 |
+| Founder memo | Founder EOD | short internal update with concrete progress and next moves | `program/artifacts/FOUNDER_EOD_2026-03-25.md` | 2026-03-25 |
+| Investor packet | Investor update | concise investor-facing progress summary | `program/artifacts/INVESTOR_UPDATE_2026-03-25.md` | 2026-03-25 |
+| Partner packet | Partner mini brief | short partner-facing reuse artifact | `program/artifacts/PARTNER_MINI_BRIEF_2026-03-25.md` | 2026-03-25 |
+| Deck packet | Category deck refresh | founder deck refresh with current proof anchors | `program/artifacts/CATEGORY_DECK_REFRESH_2026-03-25.md` | 2026-03-25 |
+| Public proof | Public build log | public-facing recap with proof-backed wins | `program/artifacts/PUBLIC_BUILD_LOG_2026-03-25.md` | 2026-03-25 |
+
+## Product proof by surface
+
+| Category | Asset | Use | Source repo/path | Freshness |
+| --- | --- | --- | --- | --- |
+| Alice deploy | Deployment technique audit | proves Alice has a real deploy path with explicit fallback/validation logic | `Render-Network-OS/555-bot: docs/ALICE_CURRENT_DEPLOYMENT_TECHNIQUE_AUDIT_2026-02-28.md` | 2026-02-28 |
+| Alice deploy | Deployment docs index | fastest entrypoint into the current Alice deploy/runbook corpus | `Render-Network-OS/555-bot: docs/ALICE_DEPLOYMENT_DOCS_INDEX.md` | 2026-04-04 |
+| Alice runtime | Five55 / Alice parity matrix | demonstrates runtime/UI parity against explicit criteria | `rndrntwrk/milaidy: docs/FIVE55_ALICE_PARITY_MATRIX.md` | 2026-03-25 |
+| Stream evidence | Acceptance closure | benchmark-style readiness proof for stream runtime/operator work | `Render-Network-OS/stream: PHASE7_UNIFIED_ACCEPTANCE_CLOSURE_2026-02-19_POST_REMEDIATION.md` | 2026-02-19 |
+| Stream evidence | Ecosystem evidence index | operator/release evidence hub for stream claims | `Render-Network-OS/stream: ECOSYSTEM_EVIDENCE_INDEX.md` | 2026-03-25 |
+| Arcade proof | Mastery dossiers | shows real game-specific operator/gameplay depth | `rndrntwrk/555-arcade-plugin: src/mastery/dossiers/` | 2026-03-08 |
+| SW4P proof | Technical whitepaper | funding-grade protocol and architecture proof | `rndrntwrk/sw4p-pro: docs/funding/SW4P_Technical_Whitepaper.md` | 2026-03-25 |
+| SW4P proof | Threat model | technical security posture for reviewer and diligence use | `rndrntwrk/sw4p-pro: docs/THREAT_MODEL.md` | 2026-03-25 |
+
+## Screenshots, diagrams, and visuals
+
+| Category | Asset | Use | Source repo/path | Freshness |
+| --- | --- | --- | --- | --- |
+| Diagram | System map image | fast architecture explanation in decks and founder notes | `images/system-map.jpeg` | current in repo |
+| Diagram | System map page | textual companion to the system-map image | `architecture/system-map.mdx` | current in repo |
+| Screenshot | Checks passed screenshot | quick visual proof for validation/readiness references | `images/checks-passed.png` | current in repo |
+
+## Quotes and claim-ready language
+
+| Category | Asset | Use | Source repo/path | Freshness |
+| --- | --- | --- | --- | --- |
+| Claim language | Partner / VC narrative | strongest reusable claim language for partner/investor writing | `program/PARTNER_VC_NARRATIVE.md` | 2026-03-25 |
+| Claim language | Outreach messages | reusable short-form language tied back to proof assets | `program/OUTREACH_MESSAGES.md` | 2026-03-25 |
+
+## Known gaps
+
+| Gap | Current fallback | Next upgrade |
+| --- | --- | --- |
+| No canonical founder demo clip is indexed here yet | use `program/artifacts/PUBLIC_BUILD_LOG_2026-03-25.md` plus live demo surfaces | add one reusable founder demo clip once a stable clip file and storage path exist |
+| No single chart pack is indexed here yet | use `program/artifacts/CATEGORY_DECK_REFRESH_2026-03-25.md` and `program/CATEGORY_DECK_BRIEF.md` | add chart exports when KPI baselines are refreshed |

--- a/program/founder-proof/README.md
+++ b/program/founder-proof/README.md
@@ -1,0 +1,29 @@
+# Founder Proof Folder
+
+This folder is the fast-retrieval surface for founder-facing proof.
+
+Use it when writing:
+
+- founder updates
+- investor notes
+- partner follow-ups
+- fundraising materials
+- category-deck refreshes
+
+## What belongs here
+
+- the shortest path to the best current proof
+- reusable screenshots, diagrams, memos, and benchmark links
+- cross-repo source pointers for the strongest product claims
+- explicit gaps, so missing proof is visible instead of rediscovered late
+
+## Rules
+
+- Do not duplicate canonical source docs here unless portability requires it.
+- Index the canonical source path first.
+- Prefer reusable evergreen proof over one-off narrative copy.
+- Demote stale proof instead of quietly deleting it.
+
+## Canonical index
+
+- `INDEX.md` is the one founder-facing entrypoint for reusable proof.


### PR DESCRIPTION
Closes #113

## Summary
- add a dedicated founder-proof folder under program/
- add a fast founder-facing proof index that points to the strongest current cross-repo evidence
- wire the new folder into the proof asset library, program README, and lightweight data room

## Validation
- git diff --check

## Notes
- SYS-006 is already closed, so this work builds on the canonical proof asset library instead of creating a parallel proof system
