### PR TITLE
Design Review #85: Add Success Metric and Proof Asset to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,16 @@
 ## Validation
 - What did you check locally?
 
+## Success Metric
+- Metric impacted:
+- Expected direction / target:
+- Measurement source:
+
+## Proof Asset
+- Evidence to capture:
+- Storage location or link:
+- Follow-up issue if deferred:
+
 ## Config / Secret Changes
 <!-- REQUIRED: check one. Reviewers use this to know whether to scrutinize auth, env, or infra code. -->
 - [ ] **None** — this PR does not touch env vars, secrets, or config


### PR DESCRIPTION
## Summary

Adds Success Metric and Proof Asset sections to the docs repo PR template.

### Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — Added Success Metric (which metric, direction/target) and Proof Asset (what to capture, where to store) sections

Part of Render-Network-OS/docs#85