### PR TITLE
docs(security): note CircleCI purge in historical scan record

### DIFF
--- a/security/QA_031_SECRET_PROTECTION_REPORT.md
+++ b/security/QA_031_SECRET_PROTECTION_REPORT.md
@@ -69,10 +69,10 @@ secret-scan layer.
 | Category | Count | Key Paths |
 |----------|-------|-----------|
 | Password in URL | 20+ | `.env.example`, `docker-compose.yml`, `k8s/base/*-secrets.yaml`, `.secrets.template.env`, `.circleci/config.yml`[^cci-purged] |
-
-[^cci-purged]: `.circleci/config.yml` was a path scanned at the time of this audit. The file has since been removed from `Render-Network-OS/stream` as part of the org-wide CircleCI purge (companion to `Render-Network-OS/555ID#22`). The historical scan record is preserved here for audit-integrity reasons; the path no longer exists in the live tree.
 | High entropy strings | 27 | `services/control-plane/prisma/schema.prisma` (19), `.env.example` (18), various docs (18 each) |
 | **Total** | **47** | |
+
+[^cci-purged]: `.circleci/config.yml` was a path scanned at the time of this audit. The file has since been removed from `Render-Network-OS/stream` as part of the org-wide CircleCI purge (companion to `Render-Network-OS/555ID#22`). The historical scan record is preserved here for audit-integrity reasons; the path no longer exists in the live tree.
 
 **Assessment:** "Password in URL" hits are from Redis/Postgres connection strings with placeholder passwords in example/template files (e.g., `redis://:password@localhost:6379`). These are intentional placeholders, not leaked credentials. High-entropy hits in `schema.prisma` are Prisma model hashes, not secrets. The SVG files are base64-encoded image data.
 

--- a/security/QA_031_SECRET_PROTECTION_REPORT.md
+++ b/security/QA_031_SECRET_PROTECTION_REPORT.md
@@ -68,7 +68,9 @@ secret-scan layer.
 
 | Category | Count | Key Paths |
 |----------|-------|-----------|
-| Password in URL | 20+ | `.env.example`, `docker-compose.yml`, `k8s/base/*-secrets.yaml`, `.secrets.template.env`, `.circleci/config.yml` |
+| Password in URL | 20+ | `.env.example`, `docker-compose.yml`, `k8s/base/*-secrets.yaml`, `.secrets.template.env`, `.circleci/config.yml`[^cci-purged] |
+
+[^cci-purged]: `.circleci/config.yml` was a path scanned at the time of this audit. The file has since been removed from `Render-Network-OS/stream` as part of the org-wide CircleCI purge (companion to `Render-Network-OS/555ID#22`). The historical scan record is preserved here for audit-integrity reasons; the path no longer exists in the live tree.
 | High entropy strings | 27 | `services/control-plane/prisma/schema.prisma` (19), `.env.example` (18), various docs (18 each) |
 | **Total** | **47** | |
 


### PR DESCRIPTION
## Summary

Single-file footnote added to `security/QA_031_SECRET_PROTECTION_REPORT.md` so a reader of the historical secret-scan record knows that `.circleci/config.yml` (listed there as a scanned path) no longer exists in `Render-Network-OS/stream` after the org-wide CircleCI purge.

The scan record itself is left unchanged — rewriting historical audit paths would falsify the audit.

## Why

Companion to:
- Render-Network-OS/555ID#22 — extracts CircleCI from the 555ID protocol repo
- Render-Network-OS/stream cleanup PR (parallel; URL to follow)

The user has confirmed an org-wide CircleCI purge, with nothing out of scope.

## Test plan

- [x] Historical scan numbers / counts unchanged
- [x] Footnote renders correctly in GitHub Markdown
- [x] No active runbooks touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)